### PR TITLE
Change status code check to 201

### DIFF
--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -66,7 +66,7 @@ trait MakesHttpRequests
             empty($payload) ? [] : ['form_params' => $payload]
         );
 
-        if ($response->getStatusCode() != 201) {
+        if (subtr($response->getStatusCode(), 0, 1)) != 2) {
             return $this->handleRequestError($response);
         }
 

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -66,7 +66,7 @@ trait MakesHttpRequests
             empty($payload) ? [] : ['form_params' => $payload]
         );
 
-        if ($response->getStatusCode() != 200) {
+        if ($response->getStatusCode() != 201) {
             return $this->handleRequestError($response);
         }
 


### PR DESCRIPTION
The API responds with a status code 201 but right now it's checking for 200. Currently an exception is thrown even though the call was successful.