### PR TITLE
Extend abillity to manage maintenance periods

### DIFF
--- a/src/Actions/ManagesMaintenancePeriods.php
+++ b/src/Actions/ManagesMaintenancePeriods.php
@@ -21,41 +21,35 @@ trait ManagesMaintenancePeriods
 
     /**
      * @param int $siteId
-     * @param int|null $stopMaintenanceAfterSeconds
+     * @param int $stopMaintenanceAfterSeconds Stops after one hour by default
      *
      * @return MaintenancePeriod
      */
-    public function startMaintenancePeriod(int $siteId, int $stopMaintenanceAfterSeconds = null): MaintenancePeriod
+    public function startSiteMaintenance(int $siteId, int $stopMaintenanceAfterSeconds = 60 * 60): MaintenancePeriod
     {
-        $payload = !$stopMaintenanceAfterSeconds ? [] : [
+        $attributes = $this->post("sites/{$siteId}/start-maintenance", [
             'stop_maintenance_after_seconds' => $stopMaintenanceAfterSeconds
-        ];
-
-        $attributes = $this->post("sites/{$siteId}/start-maintenance", $payload);
+        ]);
 
         return new MaintenancePeriod($attributes, $this);
     }
 
     /**
      * @param int $siteId
-     *
-     * @return MaintenancePeriod
      */
-    public function stopMaintenancePeriod(int $siteId): MaintenancePeriod
+    public function stopSiteMaintenance(int $siteId)
     {
-        $attributes = $this->post("sites/{$siteId}/start-maintenance");
-
-        return new MaintenancePeriod($attributes, $this);
+        $this->post("sites/{$siteId}/stop-maintenance");
     }
 
     /**
      * @param int $siteId
-     * @param string $startsAt - Y:m:d H:i
-     * @param string $endsAt - Y:m:d H:i
+     * @param string $startsAt Y:m:d H:i
+     * @param string $endsAt Y:m:d H:i
      *
      * @return MaintenancePeriod
      */
-    public function createMaintenancePeriod(int $siteId, string $startsAt, string $endsAt): MaintenancePeriod
+    public function createSiteMaintenance(int $siteId, string $startsAt, string $endsAt): MaintenancePeriod
     {
         $payload = [
             'site_id' => $siteId,
@@ -71,7 +65,7 @@ trait ManagesMaintenancePeriods
     /**
      * @param int $maintenancePeriodId
      */
-    public function deleteMaintenancePeriod(int $maintenancePeriodId)
+    public function deleteSiteMaintenance(int $maintenancePeriodId)
     {
         $this->delete("maintenance-periods/{$maintenancePeriodId}");
     }

--- a/src/Actions/ManagesMaintenancePeriods.php
+++ b/src/Actions/ManagesMaintenancePeriods.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace OhDear\PhpSdk\Actions;
+
+use OhDear\PhpSdk\Resources\MaintenancePeriod;
+
+trait ManagesMaintenancePeriods
+{
+    /**
+     * @param int $siteId
+     *
+     * @return array
+     */
+    public function maintenancePeriods(int $siteId): array
+    {
+        return $this->transformCollection(
+            $this->get("sites/{$siteId}/maintenance-periods")['data'],
+            MaintenancePeriod::class
+        );
+    }
+
+    /**
+     * @param int $siteId
+     * @param int|null $stopMaintenanceAfterSeconds
+     *
+     * @return MaintenancePeriod
+     */
+    public function startMaintenancePeriod(int $siteId, int $stopMaintenanceAfterSeconds = null): MaintenancePeriod
+    {
+        $payload = !$stopMaintenanceAfterSeconds ? [] : [
+            'stop_maintenance_after_seconds' => $stopMaintenanceAfterSeconds
+        ];
+
+        $attributes = $this->post("sites/{$siteId}/start-maintenance", $payload);
+
+        return new MaintenancePeriod($attributes, $this);
+    }
+
+    /**
+     * @param int $siteId
+     *
+     * @return MaintenancePeriod
+     */
+    public function stopMaintenancePeriod(int $siteId): MaintenancePeriod
+    {
+        $attributes = $this->post("sites/{$siteId}/start-maintenance");
+
+        return new MaintenancePeriod($attributes, $this);
+    }
+
+    /**
+     * @param int $siteId
+     * @param string $startsAt - Y:m:d H:i
+     * @param string $endsAt - Y:m:d H:i
+     *
+     * @return MaintenancePeriod
+     */
+    public function createMaintenancePeriod(int $siteId, string $startsAt, string $endsAt): MaintenancePeriod
+    {
+        $payload = [
+            'site_id' => $siteId,
+            'starts_at' => $startsAt,
+            'ends_at' => $endsAt
+        ];
+
+        $attributes = $this->post('maintenance-periods', $payload);
+
+        return new MaintenancePeriod($attributes, $this);
+    }
+
+    /**
+     * @param int $maintenancePeriodId
+     */
+    public function deleteMaintenancePeriod(int $maintenancePeriodId)
+    {
+        $this->delete("maintenance-periods/{$maintenancePeriodId}");
+    }
+}

--- a/src/Actions/ManagesMaintenancePeriods.php
+++ b/src/Actions/ManagesMaintenancePeriods.php
@@ -28,7 +28,7 @@ trait ManagesMaintenancePeriods
     public function startSiteMaintenance(int $siteId, int $stopMaintenanceAfterSeconds = 60 * 60): MaintenancePeriod
     {
         $attributes = $this->post("sites/{$siteId}/start-maintenance", [
-            'stop_maintenance_after_seconds' => $stopMaintenanceAfterSeconds
+            'stop_maintenance_after_seconds' => $stopMaintenanceAfterSeconds,
         ]);
 
         return new MaintenancePeriod($attributes, $this);
@@ -54,7 +54,7 @@ trait ManagesMaintenancePeriods
         $payload = [
             'site_id' => $siteId,
             'starts_at' => $startsAt,
-            'ends_at' => $endsAt
+            'ends_at' => $endsAt,
         ];
 
         $attributes = $this->post('maintenance-periods', $payload);

--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -39,16 +39,4 @@ trait ManagesSites
     {
         $this->delete("sites/$siteId");
     }
-
-    public function startSiteMaintenance(int $siteId, int $stopMaintenanceAfterSeconds = 60 * 60)
-    {
-        $this->post("sites/{$siteId}/start-maintenance", [
-            'stop_maintenance_after_seconds' => $stopMaintenanceAfterSeconds,
-        ]);
-    }
-
-    public function stopSiteMaintenance(int $siteId)
-    {
-        $this->post("sites/{$siteId}/stop-maintenance");
-    }
 }

--- a/src/OhDear.php
+++ b/src/OhDear.php
@@ -7,6 +7,7 @@ use OhDear\PhpSdk\Actions\ManagesBrokenLinks;
 use OhDear\PhpSdk\Actions\ManagesCertificateHealth;
 use OhDear\PhpSdk\Actions\ManagesChecks;
 use OhDear\PhpSdk\Actions\ManagesDowntime;
+use OhDear\PhpSdk\Actions\ManagesMaintenancePeriods;
 use OhDear\PhpSdk\Actions\ManagesMixedContent;
 use OhDear\PhpSdk\Actions\ManagesSites;
 use OhDear\PhpSdk\Actions\ManagesStatusPages;
@@ -20,6 +21,7 @@ class OhDear
         ManagesChecks,
         ManagesUsers,
         ManagesBrokenLinks,
+        ManagesMaintenancePeriods,
         ManagesMixedContent,
         ManagesUptime,
         ManagesDowntime,

--- a/src/Resources/MaintenancePeriod.php
+++ b/src/Resources/MaintenancePeriod.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OhDear\PhpSdk\Resources;
+
+class MaintenancePeriod extends ApiResource
+{
+    /**
+     * The id of the maintenance period.
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * The id of the site.
+     *
+     * @var int
+     */
+    public $siteId;
+
+    /**
+     * When the period will start.
+     *
+     * @var string
+     */
+    public $startsAt;
+
+    /**
+     * When the period will end.
+     *
+     * @var string
+     */
+    public $endsAt;
+}

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -13,7 +13,7 @@ class User extends ApiResource
     /** @var string */
     public $email;
 
-    /** @var email */
+    /** @var string */
     public $photoUrl;
 
     /** @var Team[] */


### PR DESCRIPTION
Hi,
the PR extends the existing methods to stop and start a maintenance period by deleting, creating and retrieving maintenance periods. I am refactoring the existing methods into their own action trait away from the `ManagesSites` trait and I stick to the method signatures for compatibility.

I am adding a Maintenance Period resource to be able to return the API results.

I need this features for the project I am currently working on that depends on the SDK. It was way faster to implement this in a PR since everything is already set up nicely on your site.

I manually tested to start, start with 10 minutes duration, stop, create, delete and retrieve maintenance periods.

Is there anything missing?

Cheers