### PR TITLE
feat: add Status Page Updates API

### DIFF
--- a/src/Actions/ManagesStatusPageUpdates.php
+++ b/src/Actions/ManagesStatusPageUpdates.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace OhDear\PhpSdk\Actions;
+
+use OhDear\PhpSdk\Resources\StatusPageUpdate;
+
+trait ManagesStatusPageUpdates
+{
+    public function statusPageUpdates(int $statusPageId): array
+    {
+        return $this->transformCollection(
+            $this->get("status-pages/{$statusPageId}/updates")['data'],
+            StatusPageUpdate::class
+        );
+    }
+
+    public function createStatusPageUpdate(array $data): StatusPageUpdate
+    {
+        $statusPageAttributes = $this->post('status-page-updates', $data);
+
+        return new StatusPageUpdate($statusPageAttributes, $this);
+    }
+
+    public function deleteStatusPageUpdate(int $statusPageUpdateId)
+    {
+        $this->delete("status-page-updates/{$statusPageUpdateId}");
+    }
+}

--- a/src/OhDear.php
+++ b/src/OhDear.php
@@ -14,6 +14,7 @@ use OhDear\PhpSdk\Actions\ManagesMixedContent;
 use OhDear\PhpSdk\Actions\ManagesPerformance;
 use OhDear\PhpSdk\Actions\ManagesSites;
 use OhDear\PhpSdk\Actions\ManagesStatusPages;
+use OhDear\PhpSdk\Actions\ManagesStatusPageUpdates;
 use OhDear\PhpSdk\Actions\ManagesUptime;
 use OhDear\PhpSdk\Actions\ManagesUsers;
 
@@ -30,6 +31,7 @@ class OhDear
         ManagesDowntime,
         ManagesCertificateHealth,
         ManagesStatusPages,
+        ManagesStatusPageUpdates,
         ManagesPerformance,
         ManagesCronChecks;
 

--- a/src/Resources/StatusPage.php
+++ b/src/Resources/StatusPage.php
@@ -17,4 +17,9 @@ class StatusPage extends ApiResource
     public string $timezone;
 
     public string $summarizedStatus;
+
+    public function updates(): array
+    {
+        return $this->ohDear->statusPageUpdates($this->id);
+    }
 }

--- a/src/Resources/StatusPageUpdate.php
+++ b/src/Resources/StatusPageUpdate.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace OhDear\PhpSdk\Resources;
+
+class StatusPageUpdate extends ApiResource
+{
+    public int $id;
+
+    public string $title;
+
+    public string $text;
+
+    public bool $pinned;
+
+    public string $severity;
+
+    public string $time;
+
+    public string $statusPageUrl;
+
+    public function delete(): void
+    {
+        $this->ohDear->deleteStatusPageUpdate($this->id);
+    }
+}


### PR DESCRIPTION
I noticed there was [an API for this](https://ohdear.app/docs/integrations/api/status-page-updates), but it's not in the PHP SDK. I was just thinking it might be useful for the Oh Dear CLI tool to be able to post updates. 🤷🏻

For the `createStatusPageUpdate()` method, I wasn't sure whether to separate it into multiple parameters, or just an array. 🤔

Feel free to use the following for the markdown docs if you'd like:

---

<details>
<summary>Copy-able Markdown documentation</summary>

# Manage your status page updates with the PHP SDK

Make sure you've [read the getting started guide first](https://ohdear.app/docs/integrations/php-sdk/getting-started). Once that's done, you should have our package & authentication ready to go.

## Retrieve all status page updates

The simplest example is one where we list all the updates for a status page.

```php
$ohDear->statusPage(1)->updates();

// Alternatively you could do this
$statusPages = $ohDear->statusPageUpdates(1);
```

This will return an array of `OhDear\PhpSdk\Resources\StatusPageUpdate` instances.

The individual attributes will be explained in the next section.

## Add a status page update through the SDK

A new status page update can be created with `createStatusPageUpdate()`.

```php
$statusPageUpdate = $ohDear->createStatusPageUpdate([
    'status_page_id' => 1,
    'title' => 'Our site is down',
    'text' => 'We are working on it!',
    'pinned' => true, 
    'severity' => 'high', // One of: info, warning, high, resolved, scheduled
    'time' => '2021-02-09 12:25', // A UTC date field for this update in the Y-m-d H:i format
]);
```

This will return an instance of `OhDear\PhpSdk\Resources\StatusPageUpdate`

You can get a few properties of a Status Page Update.

```php
$statusPageUpdate->id;
$statusPageUpdate->title;
$statusPageUpdate->text;
$statusPageUpdate->pinned;
$statusPageUpdate->severity;
$statusPageUpdate->time;
$statusPageUpdate->statusPageUrl;
```

## Deleting a status page update

A site can easily be deleted. This assumes the `$statusPageUpdate` is an instance of `OhDear\PhpSdk\Resources\StatusPageUpdate`, which you can get with the `statusPageUpdates()` method.

```php
$statusPageUpdate->delete();

// Alternatively you could do this
$ohDear->deleteStatusPageUpdate(1);
```

For more extensive understanding of the return values, please have a look at our [status page updates API documentation](https://ohdear.app/docs/integrations/api/status-page-updates).

</details>