### PR TITLE
Add sorting parameter to performance records method

### DIFF
--- a/src/Actions/ManagesPerformance.php
+++ b/src/Actions/ManagesPerformance.php
@@ -11,16 +11,21 @@ trait ManagesPerformance
      * @param string $start Short (2020-12-01) or long (2020-12-01 15:00:00) date format
      * @param string $end Short (2020-12-01) or long (2020-12-01 15:00:00) date format
      * @param string $timeframe Should be 1m or 1h
-     *
+     * @param string $sort
      * @return array
      */
-    public function performanceRecords(int $siteId, string $start, string $end, string $timeframe = '1m'): array
-    {
+    public function performanceRecords(
+        int $siteId,
+        string $start,
+        string $end,
+        string $timeframe = '1m',
+        string $sort = '-created_at'
+    ): array {
         $start = $this->convertDateFormat($start);
         $end = $this->convertDateFormat($end);
 
         return $this->transformCollection(
-            $this->get("sites/$siteId/performance-records?filter[start]={$start}&filter[end]={$end}&filter[timeframe]={$timeframe}")['data'],
+            $this->get("sites/$siteId/performance-records?filter[start]={$start}&filter[end]={$end}&filter[timeframe]={$timeframe}&sort={$sort}")['data'],
             PerformanceRecord::class
         );
     }

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -92,4 +92,13 @@ class Site extends ApiResource
     {
         return $this->ohDear->syncCronChecks($this->id, $cronCheckAttributes);
     }
+
+    public function performanceRecords(
+        string $start,
+        string $end,
+        string $timeframe = '1m',
+        string $sort = '-created_at'
+    ) : array {
+        return $this->ohDear->performanceRecords($this->id, $start, $end, $timeframe, $sort);
+    }
 }


### PR DESCRIPTION
This PR adds sorting abilities to the performance records method based on the api documentation https://ohdear.app/docs/integrations/api/performance-records#sorting-the-results

Default sorting has been set to `-created_at` in order to receive the most recent record first as specified in the api documentation.

Fixes issue #20