### PR TITLE
fix: allow `StatusPageUpdate::$text` to be nullable

### DIFF
--- a/src/Resources/StatusPageUpdate.php
+++ b/src/Resources/StatusPageUpdate.php
@@ -8,7 +8,7 @@ class StatusPageUpdate extends ApiResource
 
     public string $title;
 
-    public string $text;
+    public ?string $text;
 
     public bool $pinned;
 


### PR DESCRIPTION
The API can return `null` for the `$text` parameter, which results in a type error such as below:

![TypeError when `text` is null](https://user-images.githubusercontent.com/1899334/156186721-2934b36e-313d-4285-8cb2-e5b599de3179.png)