### PR TITLE
ci: fix Composer install for tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
                 run: cp .env.example .env
 
             -   name: Install dependencies
-                run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+                run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Run tests
                 run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
                 run: cp .env.example .env
 
             -   name: Install dependencies
-                run: composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+                run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             -   name: Run tests
                 run: vendor/bin/phpunit


### PR DESCRIPTION
The `COMPOSER_FLAGS` env variable doesn't exist in the workflow, so it it was always installing the latest version (and `--prefer-lowest` was never being tested).

Also, changed `--prefer-source` to `--prefer-dist` so that it's not cloning lots of repositories unnecessarily. Comparing the test runs in this PR (27s) compared to the ones in [`master`](https://github.com/ohdearapp/ohdear-php-sdk/actions/runs/1917453117) (9m 58s), this change makes a massive speed increase. 👍🏻