### PR TITLE
chore(deps-dev): replace PHP-CS-Fixer locally with Pint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "nesbot/carbon": "^2.65.0"
     },
     "require-dev": {
+        "laravel/pint": "^1.13",
         "pestphp/pest": "^2.8.3",
         "psalm/plugin-laravel": "^2.5",
         "vlucas/phpdotenv": "^5.5"
@@ -39,7 +40,7 @@
     },
     "scripts": {
         "psalm": "vendor/bin/psalm",
-        "format": "vendor/bin/php-cs-fixer fix",
+        "format": "vendor/bin/pint",
         "test": "vendor/bin/pest -p"
     },
     "config": {


### PR DESCRIPTION
I know the linting is automatically done within CI, but the local `format` script was still using the wrong code style fixer, and this allows people to format it locally as well.