### PR TITLE
Drop Carbon dependency, replace with `DateTimeImmutable`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "guzzlehttp/guzzle": "^6.5.8|^7.5",
-        "nesbot/carbon": "^2.65.0"
+        "guzzlehttp/guzzle": "^6.5.8|^7.5"
     },
     "require-dev": {
         "laravel/pint": "^1.13",

--- a/src/OhDear.php
+++ b/src/OhDear.php
@@ -2,7 +2,6 @@
 
 namespace OhDear\PhpSdk;
 
-use Carbon\Carbon;
 use GuzzleHttp\Client;
 use OhDear\PhpSdk\Actions\ManagesApplicationHealthChecks;
 use OhDear\PhpSdk\Actions\ManagesBrokenLinks;

--- a/src/OhDear.php
+++ b/src/OhDear.php
@@ -80,6 +80,6 @@ class OhDear
 
     public function convertDateFormat(string $date, $format = 'YmdHis'): string
     {
-        return Carbon::parse($date)->format($format);
+        return (new \DateTimeImmutable($date))->format($format);
     }
 }


### PR DESCRIPTION
With Carbon's long-awaited 3.0 release being [out the door 🎉](https://github.com/briannesbitt/Carbon/releases/tag/3.0.0), I discovered that the Oh Dear SDK was blocking the upgrade of one of our internal libraries because of its dependency on `nesbot/carbon:^2.65.0`.

As it turns out, however, Carbon is only being used by one method:

https://github.com/ohdearapp/ohdear-php-sdk/blob/d30606987eb897b34886f450527b0b733fed4649/src/OhDear.php#L81-L84

With this in mind, it seemed more efficient to just use the native `DateTimeImmutable` instead of depending on an external library, especially with a new major release of it being out in the wild now.

This PR drops the dependency on Carbon and replaces it with a simple call to `DateTimeImmutable::format()`, while keeping green checks in the tests.