### PR TITLE
supress dynamic property deprecation warnings

### DIFF
--- a/src/Resources/ApiResource.php
+++ b/src/Resources/ApiResource.php
@@ -5,8 +5,9 @@ namespace OhDear\PhpSdk\Resources;
 use OhDear\PhpSdk\OhDear;
 use ReflectionObject;
 use ReflectionProperty;
+use stdClass;
 
-class ApiResource
+class ApiResource extends stdClass
 {
     public array $attributes = [];
 


### PR DESCRIPTION
This (partially) fixes #42 and is the only thing I can do as a contributor, since I noticed a lot of the properties the API is trying to assign are not documented.