### PR TITLE
fix: add missing `split` param

### DIFF
--- a/src/Concerns/SupportsUptimeEndpoints.php
+++ b/src/Concerns/SupportsUptimeEndpoints.php
@@ -3,14 +3,15 @@
 namespace OhDear\PhpSdk\Concerns;
 
 use OhDear\PhpSdk\Dto\Uptime;
+use OhDear\PhpSdk\Enums\UptimeSplit;
 use OhDear\PhpSdk\Requests\Uptime\GetUptimeRequest;
 
 trait SupportsUptimeEndpoints
 {
     /** @return list<Uptime> */
-    public function uptime(int $monitorId, string $startedAt, string $endedAt): array
+    public function uptime(int $monitorId, string $startedAt, string $endedAt, UptimeSplit $split = UptimeSplit::Hour): array
     {
-        $request = new GetUptimeRequest($monitorId, $startedAt, $endedAt);
+        $request = new GetUptimeRequest($monitorId, $startedAt, $endedAt, $split);
 
         return $this->send($request)->dtoOrFail();
     }

--- a/src/Enums/UptimeSplit.php
+++ b/src/Enums/UptimeSplit.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OhDear\PhpSdk\Enums;
+
+enum UptimeSplit: string
+{
+    case Hour = 'hour';
+    case Day = 'day';
+    case Month = 'month';
+}

--- a/src/Requests/Uptime/GetUptimeRequest.php
+++ b/src/Requests/Uptime/GetUptimeRequest.php
@@ -3,6 +3,7 @@
 namespace OhDear\PhpSdk\Requests\Uptime;
 
 use OhDear\PhpSdk\Dto\Uptime;
+use OhDear\PhpSdk\Enums\UptimeSplit;
 use OhDear\PhpSdk\Helpers\Helpers;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -16,6 +17,7 @@ class GetUptimeRequest extends Request
         protected int $monitorId,
         protected string $startedAt,
         protected string $endedAt,
+        protected UptimeSplit $split = UptimeSplit::Hour,
     ) {}
 
     public function resolveEndpoint(): string
@@ -30,6 +32,7 @@ class GetUptimeRequest extends Request
                 'started_at' => Helpers::convertDateFormat($this->startedAt),
                 'ended_at' => Helpers::convertDateFormat($this->endedAt),
             ],
+            'split' => $this->split->value,
         ];
     }
 


### PR DESCRIPTION
Sorry, this was my bad, I thought this had a default but it's required.