### PR TITLE
Add Notification Destinations to Monitors Endpoints

### DIFF
--- a/src/Concerns/SupportsMonitorEndpoints.php
+++ b/src/Concerns/SupportsMonitorEndpoints.php
@@ -10,6 +10,7 @@ use OhDear\PhpSdk\Requests\Monitors\DeleteMonitorRequest;
 use OhDear\PhpSdk\Requests\Monitors\GetCheckSummaryRequest;
 use OhDear\PhpSdk\Requests\Monitors\GetMonitorRequest;
 use OhDear\PhpSdk\Requests\Monitors\GetMonitorsRequest;
+use OhDear\PhpSdk\Requests\Monitors\GetNotificationDestinationsRequest;
 use OhDear\PhpSdk\Requests\Monitors\UpdateMonitorRequest;
 
 /** @mixin \OhDear\PhpSdk\OhDear */
@@ -59,6 +60,13 @@ trait SupportsMonitorEndpoints
     public function checkSummary(int $monitorId, CheckType $checkType): CheckSummary
     {
         $request = new GetCheckSummaryRequest($monitorId, $checkType);
+
+        return $this->send($request)->dto();
+    }
+
+    public function notificationDestinations(int $monitorId): array
+    {
+        $request = new GetNotificationDestinationsRequest($monitorId);
 
         return $this->send($request)->dto();
     }

--- a/src/Dto/NotificationDestination.php
+++ b/src/Dto/NotificationDestination.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OhDear\PhpSdk\Dto;
+
+use Saloon\Http\Response;
+
+class NotificationDestination
+{
+    public function __construct(
+        public int $id,
+        public ?string $label,
+        public string $channel,
+        public array $destination,
+        public array $notificationTypes,
+    ) {}
+
+    public static function fromResponse(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            label: $data['label'] ?? null,
+            channel: $data['channel'],
+            destination: $data['destination'] ?? [],
+            notificationTypes: $data['notification_types'] ?? []
+        );
+    }
+
+    public static function collect(Response $response): array
+    {
+        return array_map(
+            fn (array $item) => self::fromResponse($item),
+            $response->json('data')
+        );
+    }
+}

--- a/src/Requests/Monitors/GetNotificationDestinationsRequest.php
+++ b/src/Requests/Monitors/GetNotificationDestinationsRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace OhDear\PhpSdk\Requests\Monitors;
+
+use OhDear\PhpSdk\Dto\NotificationDestination;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class GetNotificationDestinationsRequest extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        protected int $monitorId,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return "/monitors/{$this->monitorId}/notification-destinations";
+    }
+
+    public function createDtoFromResponse(Response $response): array
+    {
+        return NotificationDestination::collect($response);
+    }
+}

--- a/tests/Fixtures/Saloon/notification-destinations.json
+++ b/tests/Fixtures/Saloon/notification-destinations.json
@@ -1,0 +1,24 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Date": "Sun, 10 Aug 2025 11:45:46 GMT",
+        "Content-Type": "application\/json",
+        "Transfer-Encoding": "chunked",
+        "Connection": "keep-alive",
+        "Server": "cloudflare",
+        "Vary": "Accept-Encoding",
+        "Cache-Control": "no-cache, private",
+        "X-Ratelimit-Limit": "500",
+        "X-Ratelimit-Remaining": "499",
+        "Access-Control-Allow-Origin": "*",
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-Xss-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Report-To": "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https:\/\/a.nel.cloudflare.com\/report\/v4?s=CQXyjC5xJ01g2W8S6d%2F692vA3tqoHzqWh4FFt5nlf7JditDyFY%2FC3Xw6vqQo6fFb68HML2MXgmmuzkAToPGj2scG%2FzyH3F8FbadBNdVGQA%3D%3D\"}]}",
+        "Cf-Cache-Status": "BYPASS",
+        "Nel": "{\"report_to\":\"cf-nel\",\"success_fraction\":0.0,\"max_age\":604800}",
+        "CF-RAY": "96cf3fbaabceb71b-BRU"
+    },
+    "data": "{\"data\":[{\"id\": 456,\"channel\":\"mail\"}],\"links\":{\"first\":\"\\\/?page=1\",\"last\":\"\\\/?page=1\",\"prev\":null,\"next\":null},\"meta\":{\"current_page\":1,\"from\":null,\"last_page\":1,\"links\":[{\"url\":null,\"label\":\"&laquo; Previous\",\"active\":false},{\"url\":\"\\\/?page=1\",\"label\":\"1\",\"active\":true},{\"url\":null,\"label\":\"Next &raquo;\",\"active\":false}],\"path\":\"\\\/\",\"per_page\":1000,\"to\":null,\"total\":1}}",
+    "context": []
+}

--- a/tests/OhDearTests/MonitorsTest.php
+++ b/tests/OhDearTests/MonitorsTest.php
@@ -6,6 +6,7 @@ use OhDear\PhpSdk\Requests\Monitors\DeleteMonitorRequest;
 use OhDear\PhpSdk\Requests\Monitors\GetCheckSummaryRequest;
 use OhDear\PhpSdk\Requests\Monitors\GetMonitorRequest;
 use OhDear\PhpSdk\Requests\Monitors\GetMonitorsRequest;
+use OhDear\PhpSdk\Requests\Monitors\GetNotificationDestinationsRequest;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
@@ -70,4 +71,16 @@ it('can get check summary for a monitor', function () {
     $checkSummary = $this->ohDear->checkSummary(82060, CheckType::CertificateHealth);
 
     expect($checkSummary->result)->toBe('succeeded');
+});
+
+it('can get notification destinations for a monitor', function () {
+    MockClient::global([
+        GetNotificationDestinationsRequest::class => MockResponse::fixture('notification-destinations'),
+    ]);
+
+    $notificationDestinations = $this->ohDear->notificationDestinations(82060);
+
+    foreach ($notificationDestinations as $notificationDestination) {
+        expect($notificationDestination->id)->toBeInt();
+    }
 });


### PR DESCRIPTION
Support the Notification Destinations Endpoints for Monitors. Currently documented for the API - [Notification Destinations](https://ohdear.app/docs/integrations/the-oh-dear-api#notification-destinations)